### PR TITLE
feat: add AIStor Tables + Dremio Enterprise tutorial

### DIFF
--- a/aistor-tables-dremio/.env.example
+++ b/aistor-tables-dremio/.env.example
@@ -1,0 +1,17 @@
+# AIStor Tables + Dremio Integration Configuration
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+
+# MinIO AIStor EDGE Image
+# Find releases at: https://quay.io/repository/minio/aistor/minio?tab=tags
+MINIO_TEST_IMAGE=quay.io/minio/aistor/minio:EDGE.2025-12-13T08-46-12Z
+
+# MinIO License (required for Tables feature)
+# Get a license from https://subnet.min.io
+MINIO_LICENSE=your-aistor-license-key-here
+
+# Dremio Enterprise (RESTCATALOG source requires Enterprise, not Community Edition)
+# Get a 30-day trial at https://www.dremio.com/get-started/
+# Login to quay.io with your trial image pull credentials before running:
+#   docker login quay.io -u '<trial-robot-account>' -p '<trial-token>'
+DREMIO_IMAGE=quay.io/dremio/dremio-enterprise:26.1.4

--- a/aistor-tables-dremio/.gitignore
+++ b/aistor-tables-dremio/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+*.pyc
+__pycache__/
+.ipynb_checkpoints/
+*.egg-info/
+dist/
+build/
+.env
+.env.local

--- a/aistor-tables-dremio/README.md
+++ b/aistor-tables-dremio/README.md
@@ -1,0 +1,228 @@
+# Dremio + AIStor Tables
+
+[![MinIO](https://raw.githubusercontent.com/minio/minio/master/.github/logo.svg?sanitize=true)](https://min.io)
+
+Query Apache Iceberg tables on MinIO AIStor using Dremio Enterprise. This tutorial demonstrates how to connect Dremio to AIStor's built-in Iceberg REST Catalog, create tables with PyIceberg, and run SQL analytics.
+
+> **Enterprise Licenses Required**: Both AIStor Tables and Dremio Enterprise require valid licenses.
+> - **AIStor**: Contact [enterprise@min.io](mailto:enterprise@min.io) or visit [SUBNET](https://subnet.min.io)
+> - **Dremio Enterprise**: The RESTCATALOG source type is **not available** in Dremio Community Edition. Get a [30-day trial](https://www.dremio.com/get-started/).
+
+## Architecture
+
+```
+┌─────────────────┐     ┌──────────────────────────────┐
+│     Dremio      │     │      MinIO AIStor             │
+│  (Query Engine) │     │                               │
+│                 ├────►│  /_iceberg  (REST Catalog API) │
+│  SQL Analytics  │     │      Table metadata, schemas  │
+│                 │     │                               │
+│                 ├────►│  S3 API    (Data Access)       │
+│                 │     │      Parquet data files       │
+└─────────────────┘     └──────────────────────────────┘
+        ▲
+        │
+┌───────┴─────────┐
+│    Jupyter       │
+│  (PyIceberg)     │
+│  Table creation  │
+│  & data loading  │
+└─────────────────┘
+```
+
+## Prerequisites
+
+- Docker and Docker Compose
+- AIStor enterprise license (for Tables feature)
+- Dremio Enterprise trial or license (for RESTCATALOG source type)
+
+## Quick Start
+
+```bash
+git clone <this-repo>
+cd aistor-tables-dremio
+```
+
+1. **Set your AIStor license** in `.env`:
+   ```bash
+   MINIO_LICENSE=your-license-key-here
+   ```
+
+2. **Login to Dremio Enterprise registry** (required to pull the Enterprise image):
+   ```bash
+   docker login quay.io -u '<trial-robot-account>' -p '<trial-token>'
+   ```
+   You'll receive these credentials when you sign up for the [Dremio Enterprise trial](https://www.dremio.com/get-started/).
+
+3. **Start all services:**
+   ```bash
+   ./scripts/run.sh
+   ```
+
+4. **Complete Dremio first-time setup** at http://localhost:9047:
+   - Accept the EULA
+   - Create your admin account (username and password)
+
+5. **Open Jupyter** at http://localhost:8888 and run `notebooks/DremioAIStorTables.ipynb`
+
+## Access Points
+
+| Service | URL | Credentials |
+|---------|-----|-------------|
+| MinIO Console | http://localhost:9001 | minioadmin / minioadmin |
+| Dremio UI | http://localhost:9047 | Create on first login |
+| Jupyter Notebook | http://localhost:8888 | No password |
+
+## What the Notebook Does
+
+The `DremioAIStorTables.ipynb` notebook walks through:
+
+1. **Creates a warehouse and namespace** on AIStor via the Iceberg REST API
+2. **Creates three Iceberg tables** using PyIceberg:
+   - `sales.customers` (20 rows)
+   - `sales.products` (15 rows)
+   - `sales.orders` (50 rows)
+3. **Creates an Iceberg View** (`sales.revenue_by_region`)
+4. **Configures the Dremio source** via API (RESTCATALOG type)
+5. **Runs SQL queries** through Dremio, including multi-table joins
+
+## Dremio Source Configuration
+
+The notebook configures the Dremio source automatically. If you want to add it manually via the Dremio UI, use these settings:
+
+**Source Type:** Iceberg REST Catalog (`RESTCATALOG`)
+
+### General Settings
+
+| Setting | Value |
+|---------|-------|
+| Name | `aistor_tables` |
+| REST Endpoint URI | `http://minio:9000/_iceberg` |
+
+### Properties (propertyList)
+
+| Property | Value |
+|----------|-------|
+| `warehouse` | `dremio-warehouse` |
+| `rest.sigv4-enabled` | `true` |
+| `rest.signing-name` | `s3tables` |
+| `rest.signing-region` | `dummy` |
+| `rest.access-key-id` | `minioadmin` |
+| `rest.secret-access-key` | `minioadmin` |
+| `fs.s3a.endpoint` | `minio:9000` |
+| `fs.s3a.path.style.access` | `true` |
+| `fs.s3a.connection.ssl.enabled` | `false` |
+| `fs.s3a.aws.credentials.provider` | `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` |
+| `dremio.s3.compat` | `true` |
+
+### Secret Properties (secretPropertyList)
+
+| Property | Value |
+|----------|-------|
+| `fs.s3a.access.key` | `minioadmin` |
+| `fs.s3a.secret.key` | `minioadmin` |
+
+> **Note:** `rest.access-key-id` and `rest.secret-access-key` go in **propertyList**, not secretPropertyList. The `dremio.s3.compat` property is required for MinIO and other S3-compatible storage.
+
+## Example SQL Queries
+
+Once the source is configured and tables are populated, try these in the Dremio SQL editor:
+
+```sql
+-- Customer list
+SELECT * FROM aistor_tables.sales.customers;
+
+-- Top orders with customer and product details
+SELECT
+    c.name AS customer,
+    p.product_name,
+    o.quantity,
+    o.total_amount,
+    o.order_date
+FROM aistor_tables.sales.orders o
+JOIN aistor_tables.sales.customers c ON o.customer_id = c.customer_id
+JOIN aistor_tables.sales.products p ON o.product_id = p.product_id
+ORDER BY o.total_amount DESC
+LIMIT 20;
+
+-- Revenue by region
+SELECT
+    region,
+    COUNT(*) AS order_count,
+    SUM(total_amount) AS total_revenue,
+    ROUND(AVG(total_amount), 2) AS avg_order_value
+FROM aistor_tables.sales.orders
+WHERE status = 'Completed'
+GROUP BY region
+ORDER BY total_revenue DESC;
+```
+
+## Troubleshooting
+
+### RESTCATALOG source type not available
+
+The RESTCATALOG source type is only available in **Dremio Enterprise**, not the Community (OSS) edition. If you don't see it in the source type dropdown, verify you're running the Enterprise image (`quay.io/dremio/dremio-enterprise`).
+
+### Source status is "good" but queries fail
+
+The most common issue is the `fs.s3a.endpoint` property. It must be **just the host:port** without the `http://` scheme:
+
+| Setting | Correct | Wrong |
+|---------|---------|-------|
+| `fs.s3a.endpoint` | `minio:9000` | `http://minio:9000` |
+
+The `http://` prefix causes S3A to treat "http" as a hostname, resulting in `UnknownHostException: http: Name or service not known`.
+
+You must also set:
+- `fs.s3a.connection.ssl.enabled` to `false` for non-TLS connections
+- `dremio.s3.compat` to `true` for MinIO/S3-compatible storage
+
+### Dremio takes a long time to start
+
+Dremio typically needs 60-90 seconds to fully initialize. The startup script waits for this automatically.
+
+### Dremio first-time setup
+
+On first launch, Dremio requires you to create an admin user account. You can do this via the UI at http://localhost:9047, or automate it with Python (recommended — avoids shell escaping issues with special characters in passwords):
+
+```python
+import requests
+
+requests.put("http://localhost:9047/apiv2/bootstrap/firstuser",
+    json={
+        "userName": "admin",
+        "firstName": "Admin",
+        "lastName": "User",
+        "email": "admin@example.com",
+        "password": "your-password-here",
+        "role": "admin"
+    }
+)
+```
+
+> **Note:** Avoid using `curl -d` with passwords containing `!` or other shell-special characters — bash history expansion can silently corrupt the value. Python bypasses this entirely.
+
+After creating your account, update `DREMIO_USER` and `DREMIO_PASS` in notebook cell 7 before running the Dremio sections.
+
+### Warehouse not found errors
+
+Make sure you run the notebook cells in order. The warehouse must be created before PyIceberg can connect, and before Dremio can query tables.
+
+### Connection refused from Dremio
+
+Inside Docker Compose, services communicate using container names. Dremio reaches MinIO at `minio:9000`, not `localhost:9000`.
+
+### Dremio API authentication
+
+Dremio uses a non-standard authorization header format: `_dremio{TOKEN}` (not `Bearer {TOKEN}`). The notebook handles this automatically.
+
+## Stop Services
+
+```bash
+./scripts/run.sh --stop
+```
+
+## License
+
+- MinIO AIStor Tables requires a valid enterprise license. Contact [enterprise@min.io](mailto:enterprise@min.io) for licensing.
+- Dremio Enterprise requires a valid license. Get a [30-day trial](https://www.dremio.com/get-started/).

--- a/aistor-tables-dremio/blog-dremio-aistor-tables.md
+++ b/aistor-tables-dremio/blog-dremio-aistor-tables.md
@@ -1,0 +1,295 @@
+# Run SQL Analytics on AIStor Tables with Dremio
+
+Apache Iceberg has become the default table format for analytics on object storage. The appeal is straightforward: store data as Parquet files on S3-compatible storage, manage it through a catalog, and query it from any engine that speaks Iceberg. No vendor lock-in on the query side, no proprietary formats on the storage side.
+
+The harder question has always been the catalog. Iceberg tables need something to track metadata -- which Parquet files belong to which table, what the schema looks like, where the latest snapshot lives. Historically, that meant running a Hive Metastore backed by PostgreSQL, or adopting a managed catalog service like AWS Glue. Either way, it's another system to deploy, secure, and maintain alongside your actual storage.
+
+MinIO AIStor Tables takes a different approach. The Iceberg REST Catalog is built directly into the storage server. There is no external metastore. When you write a table, the catalog metadata and the Parquet data files live on the same MinIO cluster, managed by the same process. This eliminates an entire tier of infrastructure from the lakehouse stack.
+
+This post walks through connecting Dremio -- a SQL analytics engine with native Iceberg support -- to AIStor Tables. We will create tables with PyIceberg, then query them from Dremio using standard SQL. Everything runs in Docker Compose, and a companion repository has the full working setup.
+
+## Why This Combination
+
+AIStor Tables and Dremio serve different layers of the analytics stack, and the integration between them is worth understanding.
+
+**AIStor Tables** is the storage and catalog layer. It exposes two APIs from a single endpoint:
+
+- The **Iceberg REST Catalog API** at `/_iceberg` for metadata operations -- creating warehouses, namespaces, tables, and views. PyIceberg, Spark, Trino, and Dremio all speak this protocol.
+- The **S3 API** for reading and writing the actual Parquet data files. Any S3-compatible client works here.
+
+Because both APIs run on the same server, there is no network hop between catalog lookups and data reads. The catalog knows exactly where the data lives because it manages the storage directly.
+
+**Dremio** is the query engine layer. It connects to the Iceberg REST Catalog to discover tables, then reads the Parquet files over S3 to execute queries. Dremio supports the `RESTCATALOG` source type, which is purpose-built for this pattern. You point it at a catalog endpoint and an S3 endpoint, and it handles the rest -- predicate pushdown into Parquet, partition pruning via Iceberg metadata, and columnar reads for only the columns your query touches.
+
+The practical result is a two-component analytics stack: MinIO for storage and catalog, Dremio for SQL. No Hive Metastore, no PostgreSQL for catalog state, no Glue dependency. Data engineers write tables with PyIceberg or Spark, analysts query them with SQL in Dremio.
+
+## Architecture
+
+The data flow has two paths:
+
+```
+┌─────────────────┐       ┌──────────────────────────────────┐
+│     Dremio      │       │         MinIO AIStor              │
+│  (Query Engine) │       │                                   │
+│                 ├──────►│  /_iceberg  (REST Catalog API)    │
+│                 │  (1)  │    Table metadata, schemas,       │
+│                 │       │    snapshot tracking               │
+│                 │       │                                   │
+│                 ├──────►│  S3 API    (Data Access)          │
+│                 │  (2)  │    Parquet data files             │
+└─────────────────┘       └──────────────────────────────────┘
+```
+
+1. Dremio calls the Iceberg REST Catalog to list namespaces, load table metadata, and resolve file locations.
+2. Dremio reads Parquet data files over the S3 API, applying predicate pushdown and column pruning.
+
+Both paths terminate at the same MinIO server. Authentication uses SigV4 signing for catalog requests and standard S3 credentials for data access.
+
+## Setting Up the Environment
+
+The companion repository provides a Docker Compose stack with three services: MinIO AIStor, Dremio Enterprise, and Jupyter.
+
+### Prerequisites
+
+- Docker and Docker Compose
+- An AIStor enterprise license
+- A Dremio Enterprise license or trial
+
+### Licensing
+
+Both AIStor Tables and Dremio Enterprise require licenses to run. Here is how to obtain each one.
+
+**AIStor**: The Tables feature requires an AIStor enterprise license. Go to [min.io/download](https://www.min.io/download) to request a license key. This is a single string that you set as an environment variable in the `.env` file. MinIO picks it up automatically on startup -- no UI step required.
+
+**Dremio Enterprise**: The `RESTCATALOG` source type is only available in Dremio Enterprise -- it is not included in the Community (OSS) edition. Register at [dremio.com/get-started](https://www.dremio.com/get-started/) for a 30-day free trial. The process is fully automated -- no sales call required. After registering, you receive an email with:
+
+1. **Container registry credentials** -- a robot account username and token for pulling the Enterprise Docker image from `quay.io`
+2. **A license key** -- entered through the Dremio UI on first launch (or included in a `values-overrides.yaml` for Kubernetes deployments)
+
+The trial gives full access to all Enterprise features for 30 days.
+
+### Starting the Stack
+
+Clone the repository:
+
+```bash
+git clone https://github.com/miniohq/aistor-tables-dremio.git
+cd aistor-tables-dremio
+```
+
+Open `.env` and set your AIStor license:
+
+```
+MINIO_LICENSE=your-actual-license-key
+```
+
+Log in to the Dremio Enterprise container registry using the credentials from your trial signup:
+
+```bash
+docker login quay.io -u '<trial-robot-account>' -p '<trial-token>'
+```
+
+Then start everything:
+
+```bash
+./scripts/run.sh
+```
+
+The script waits for each service to become healthy before printing access URLs:
+
+| Service | URL | Credentials |
+|---------|-----|-------------|
+| MinIO Console | http://localhost:9001 | minioadmin / minioadmin |
+| Dremio UI | http://localhost:9047 | Created on first login |
+| Jupyter | http://localhost:8888 | No password |
+
+On first launch, open the Dremio UI at http://localhost:9047 to complete the initial setup:
+
+1. **Accept the EULA**
+2. **Create an admin account** -- choose a username and password (you will need these for the notebook)
+3. **Enter your Dremio license key** -- if prompted, paste the license key from your trial registration
+
+The AIStor license is handled automatically through the `MINIO_LICENSE` environment variable in `.env` -- no manual UI step is needed for MinIO.
+
+## Creating Tables with PyIceberg
+
+The included Jupyter notebook handles the full workflow. Here is what it does and why.
+
+### Warehouse and Namespace
+
+AIStor Tables organizes data into warehouses and namespaces. A warehouse is the top-level container (analogous to a database server), and namespaces organize tables within it (analogous to schemas).
+
+```python
+# Create warehouse
+resp = make_request("POST", "/v1/warehouses", json.dumps({
+    "name": "dremio-warehouse"
+}))
+```
+
+```python
+# Create namespace
+resp = make_request("POST", "/v1/dremio-warehouse/namespaces", json.dumps({
+    "namespace": ["sales"]
+}))
+```
+
+These are SigV4-signed HTTP calls to the Iceberg REST API. The signing uses `s3tables` as the service name, which is the convention for Iceberg REST endpoints on AIStor.
+
+### Writing Tables
+
+PyIceberg connects to the same REST Catalog API:
+
+```python
+catalog = load_catalog(
+    "aistor",
+    type="rest",
+    uri="http://minio:9000/_iceberg",
+    warehouse="dremio-warehouse",
+    **{
+        "rest.sigv4-enabled": "true",
+        "rest.signing-name": "s3tables",
+        "rest.signing-region": "dummy",
+        "s3.access-key-id": "minioadmin",
+        "s3.secret-access-key": "minioadmin",
+        "s3.endpoint": "http://minio:9000",
+        "s3.path-style-access": "true",
+    }
+)
+```
+
+From here, creating and populating tables uses standard PyIceberg:
+
+```python
+customers_table = catalog.create_table("sales.customers", schema=customers_schema)
+customers_table.append(customers_data)
+```
+
+The notebook creates three related tables -- `customers`, `products`, and `orders` -- to demonstrate multi-table joins later in Dremio.
+
+### Iceberg Views
+
+The notebook also creates an Iceberg View through the REST API. Views are stored in the catalog alongside tables and are visible to any query engine that connects:
+
+```python
+view_payload = {
+    "name": "revenue_by_region",
+    "schema": { ... },
+    "view-version": {
+        "representations": [{
+            "type": "sql",
+            "sql": "SELECT region, SUM(total_amount) as total_revenue ...",
+            "dialect": "spark"
+        }]
+    }
+}
+```
+
+## Connecting Dremio to AIStor Tables
+
+This is where the configuration details matter. Dremio's `RESTCATALOG` source type needs two things: the catalog endpoint for metadata and the S3 endpoint for data files. Both point to the same MinIO server, but they use different URL formats.
+
+### The Source Configuration
+
+```python
+source_config = {
+    "entityType": "source",
+    "name": "aistor_tables",
+    "type": "RESTCATALOG",
+    "config": {
+        "restEndpointUri": "http://minio:9000/_iceberg",
+        "propertyList": [
+            {"name": "warehouse", "value": "dremio-warehouse"},
+            {"name": "rest.sigv4-enabled", "value": "true"},
+            {"name": "rest.signing-name", "value": "s3tables"},
+            {"name": "rest.signing-region", "value": "dummy"},
+            {"name": "rest.access-key-id", "value": "minioadmin"},
+            {"name": "rest.secret-access-key", "value": "minioadmin"},
+            {"name": "fs.s3a.endpoint", "value": "minio:9000"},
+            {"name": "fs.s3a.path.style.access", "value": "true"},
+            {"name": "fs.s3a.connection.ssl.enabled", "value": "false"},
+            {"name": "fs.s3a.aws.credentials.provider",
+             "value": "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"},
+            {"name": "dremio.s3.compat", "value": "true"}
+        ],
+        "secretPropertyList": [
+            {"name": "fs.s3a.access.key", "value": "minioadmin"},
+            {"name": "fs.s3a.secret.key", "value": "minioadmin"}
+        ]
+    }
+}
+```
+
+A few things to note here, since they are common sources of configuration errors:
+
+**`restEndpointUri` vs `fs.s3a.endpoint`**: The REST endpoint keeps the `http://` scheme because Dremio's HTTP client needs it. The S3A endpoint must be **just the host and port** -- `minio:9000`, not `http://minio:9000`. The Hadoop S3A library treats a scheme prefix as a hostname, which leads to `UnknownHostException: http: Name or service not known`.
+
+**`dremio.s3.compat`**: This must be `true` for S3-compatible object storage. Without it, Dremio may attempt AWS-specific behaviors that MinIO does not support.
+
+**`fs.s3a.connection.ssl.enabled`**: Must be `false` for non-TLS connections. If `fs.s3a.endpoint` has no scheme (as required) and this flag is not explicitly set to `false`, S3A defaults to HTTPS and the connection fails.
+
+**REST credentials in `propertyList`**: The `rest.access-key-id` and `rest.secret-access-key` properties go in the regular `propertyList`, not in `secretPropertyList`. The S3 data credentials (`fs.s3a.access.key` / `fs.s3a.secret.key`) go in `secretPropertyList`.
+
+## Querying from Dremio
+
+Once the source is connected, tables are immediately available in Dremio's SQL editor. The naming convention is `source.namespace.table`:
+
+```sql
+SELECT * FROM aistor_tables.sales.customers;
+```
+
+Multi-table joins work as expected:
+
+```sql
+SELECT
+    c.name AS customer,
+    p.product_name,
+    o.quantity,
+    o.total_amount,
+    o.order_date
+FROM aistor_tables.sales.orders o
+JOIN aistor_tables.sales.customers c ON o.customer_id = c.customer_id
+JOIN aistor_tables.sales.products p ON o.product_id = p.product_id
+ORDER BY o.total_amount DESC
+LIMIT 20;
+```
+
+Dremio pushes predicates and projections down into the Parquet reads, so queries that filter on specific columns or date ranges benefit from Iceberg's metadata-driven pruning without any manual optimization.
+
+Aggregations work directly:
+
+```sql
+SELECT
+    region,
+    COUNT(*) AS order_count,
+    SUM(total_amount) AS total_revenue,
+    ROUND(AVG(total_amount), 2) AS avg_order_value
+FROM aistor_tables.sales.orders
+WHERE status = 'Completed'
+GROUP BY region
+ORDER BY total_revenue DESC;
+```
+
+The notebook automates these queries via the Dremio REST API and displays results in pandas DataFrames, but the same SQL works in the Dremio UI at http://localhost:9047.
+
+## What This Looks Like in Production
+
+The Docker Compose setup in this tutorial uses a single MinIO node and a single Dremio node. A production deployment looks different in scale but not in architecture:
+
+- **AIStor** runs as a distributed cluster with erasure coding across multiple nodes. The Iceberg REST Catalog scales with the storage cluster -- there is no separate catalog database to size or replicate.
+- **Dremio** runs as a coordinator-executor cluster. Multiple executors read Parquet files in parallel from MinIO, and the coordinator merges results.
+- The **connection configuration** is the same. The `RESTCATALOG` source properties are identical whether MinIO is a single Docker container or a 32-node production cluster. The only things that change are the endpoint URLs and credentials.
+
+This is the operational advantage of having the catalog built into the storage layer. There is no Hive Metastore to upgrade, no PostgreSQL replica set for catalog state, no consistency concerns between the catalog and the data it describes. The catalog and the data are managed by the same system.
+
+## Try It
+
+The full working setup is in the companion repository:
+
+```bash
+git clone https://github.com/miniohq/aistor-tables-dremio.git
+cd aistor-tables-dremio
+# Set your license in .env
+./scripts/run.sh
+```
+
+Open Jupyter at http://localhost:8888, run the `DremioAIStorTables.ipynb` notebook, and you will have tables on AIStor queryable from Dremio in a few minutes.

--- a/aistor-tables-dremio/docker-compose.yaml
+++ b/aistor-tables-dremio/docker-compose.yaml
@@ -1,0 +1,69 @@
+# AIStor Tables + Dremio Integration
+# Single MinIO node with Dremio Enterprise and Jupyter
+
+services:
+  minio:
+    image: ${MINIO_TEST_IMAGE}
+    pull_policy: if_not_present
+    hostname: minio
+    command: server --console-address ":9001" /data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_LICENSE: ${MINIO_LICENSE}
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+    volumes:
+      - minio_data:/data
+    networks:
+      - dremio_aistor
+
+  dremio:
+    image: ${DREMIO_IMAGE:-quay.io/dremio/dremio-enterprise:26.1.4}
+    platform: linux/amd64
+    depends_on:
+      minio:
+        condition: service_healthy
+    ports:
+      - "9047:9047"
+      - "31010:31010"
+      - "32010:32010"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -o /dev/null -w '%{http_code}' http://localhost:9047 | grep -qE '(200|302|403)'"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    volumes:
+      - dremio_data:/opt/dremio/data
+    networks:
+      - dremio_aistor
+
+  jupyter:
+    image: quay.io/jupyter/pyspark-notebook:2024-10-14
+    depends_on:
+      minio:
+        condition: service_healthy
+    command: start-notebook.sh --NotebookApp.token=''
+    environment:
+      MINIO_HOST: http://minio:9000
+    ports:
+      - "8888:8888"
+    volumes:
+      - ./notebooks:/home/jovyan/notebooks
+    networks:
+      - dremio_aistor
+
+networks:
+  dremio_aistor:
+
+volumes:
+  minio_data:
+  dremio_data:

--- a/aistor-tables-dremio/dremio_tpcdc_yaml
+++ b/aistor-tables-dremio/dremio_tpcdc_yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: run-benchmark-ref-withcache-1tb-512mb-partition
+  labels:
+    app: benchmark-kit
+spec:
+  restartPolicy: Never
+  containers:
+    - name: benchmark-kit
+      image: registry.min.dev/data-science/perf-testing:latest
+      imagePullPolicy: Always
+      command: ["./benchmark-kit/run_benchmark.sh", "wref"]
+      env:
+        # S3 Configuration
+        - name: S3_ENDPOINT_URL
+          value: "http://compute-1.min.dc:30001"
+        - name: S3_ACCESS_KEY
+          value: "minio"
+        - name: S3_SECRET_KEY
+          value: "minio123"
+        - name: S3_BUCKET_NAME
+          value: "tpcds"
+        - name: S3_FOLDER_NAME
+          value: "1Tb_512Mb_partition"
+        # Iceberg Configuration
+        - name: ICEBERG_BUCKET_NAME
+          value: "iceberg"
+        - name: ICEBERG_FOLDER_NAME
+          value: "1Tb_512Mb_partition"
+        # Dremio Configuration
+        - name: DREMIO_USERNAME
+          value: "pedro"
+        - name: DREMIO_PASSWORD
+          value: "ui39GnZDQqn26Yy"
+        - name: DREMIO_URL
+          value: "http://dremio-client.dremio-v26.svc.cluster.local:9047"
+        - name: DREMIO_SOURCE_NAME
+          value: tpcds
+        - name: NESSIE_SOURCE_NAME
+          value: "pedros nessie"
+        - name: DREMIO_JDBC_HOST
+          value: dremio-client.dremio-v26.svc.cluster.local
+        - name: DREMIO_JDBC_PORT
+          value: "31010"
+        - name: BENCHMARK_BUCKET
+          value: benchmark-results

--- a/aistor-tables-dremio/notebooks/DremioAIStorTables.ipynb
+++ b/aistor-tables-dremio/notebooks/DremioAIStorTables.ipynb
@@ -1,0 +1,810 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Querying AIStor Tables with Dremio\n",
+    "\n",
+    "This notebook demonstrates how to:\n",
+    "1. Create Iceberg tables on AIStor using PyIceberg\n",
+    "2. Populate them with sample e-commerce data\n",
+    "3. Create an Iceberg View\n",
+    "4. Configure Dremio to connect to AIStor Tables\n",
+    "5. Query the tables from Dremio\n",
+    "\n",
+    "**Architecture:**\n",
+    "```\n",
+    "Dremio (Query Engine)\n",
+    "  │\n",
+    "  ├─ Iceberg REST Catalog API (SigV4) ── minio:9000/_iceberg\n",
+    "  │   (table metadata, schema, snapshots)\n",
+    "  │\n",
+    "  └─ S3 API (data access) ───────────── minio:9000\n",
+    "      (Parquet data files)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Setup & Install Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q \"pyiceberg[s3fs]\" boto3 requests pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import json\n",
+    "import requests\n",
+    "import pandas as pd\n",
+    "import pyarrow as pa\n",
+    "from datetime import datetime\n",
+    "\n",
+    "# Add notebooks directory to path for sigv4 helper\n",
+    "sys.path.insert(0, os.path.dirname(os.path.abspath('sigv4.py')))\n",
+    "import sigv4\n",
+    "\n",
+    "# Connection settings\n",
+    "HOST = os.environ.get(\"MINIO_HOST\", \"http://minio:9000\")\n",
+    "ACCESS_KEY = \"minioadmin\"\n",
+    "SECRET_KEY = \"minioadmin\"\n",
+    "WAREHOUSE_NAME = \"dremio-warehouse\"\n",
+    "\n",
+    "print(f\"MinIO Host: {HOST}\")\n",
+    "print(f\"Warehouse:  {WAREHOUSE_NAME}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Create Warehouse & Namespace\n",
+    "\n",
+    "AIStor Tables uses the Iceberg REST Catalog API. We first create a **warehouse** (top-level container) and then a **namespace** to organize our tables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def make_request(method, path, body=\"\"):\n    \"\"\"Make a SigV4-signed request to the AIStor Iceberg REST API.\"\"\"\n    url = f\"{HOST}/_iceberg{path}\"\n    headers = {\"Content-Type\": \"application/json\"}\n    signed = sigv4.sign(\n        method, url, body, HOST, headers,\n        access_key=ACCESS_KEY, secret_key=SECRET_KEY\n    )\n    resp = requests.request(\n        method, url,\n        headers=dict(signed.headers),\n        data=body\n    )\n    return resp\n\n# Create warehouse\nresp = make_request(\"POST\", \"/v1/warehouses\", json.dumps({\n    \"name\": WAREHOUSE_NAME\n}))\nif resp.status_code in [200, 201]:\n    print(f\"Warehouse '{WAREHOUSE_NAME}' created\")\nelif resp.status_code == 409:\n    print(f\"Warehouse '{WAREHOUSE_NAME}' already exists\")\nelse:\n    print(f\"Warehouse creation: {resp.status_code} - {resp.text}\")"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create namespace\n",
+    "resp = make_request(\"POST\", f\"/v1/{WAREHOUSE_NAME}/namespaces\", json.dumps({\n",
+    "    \"namespace\": [\"sales\"]\n",
+    "}))\n",
+    "if resp.status_code in [200, 201]:\n",
+    "    print(\"Namespace 'sales' created\")\n",
+    "elif resp.status_code == 409:\n",
+    "    print(\"Namespace 'sales' already exists\")\n",
+    "else:\n",
+    "    print(f\"Namespace creation: {resp.status_code} - {resp.text}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Initialize PyIceberg Catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyiceberg.catalog import load_catalog\n",
+    "\n",
+    "catalog = load_catalog(\n",
+    "    \"aistor\",\n",
+    "    type=\"rest\",\n",
+    "    uri=f\"{HOST}/_iceberg\",\n",
+    "    warehouse=WAREHOUSE_NAME,\n",
+    "    **{\n",
+    "        \"rest.sigv4-enabled\": \"true\",\n",
+    "        \"rest.signing-name\": \"s3tables\",\n",
+    "        \"rest.signing-region\": \"dummy\",\n",
+    "        \"s3.access-key-id\": ACCESS_KEY,\n",
+    "        \"s3.secret-access-key\": SECRET_KEY,\n",
+    "        \"s3.endpoint\": HOST,\n",
+    "        \"s3.path-style-access\": \"true\",\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "print(\"PyIceberg catalog connected\")\n",
+    "print(f\"Namespaces: {catalog.list_namespaces()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Create & Populate Tables\n",
+    "\n",
+    "We'll create three related tables representing a simple e-commerce data model:\n",
+    "- **customers** - Customer profiles\n",
+    "- **products** - Product catalog\n",
+    "- **orders** - Sales transactions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Customers Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "customers_schema = pa.schema([\n",
+    "    pa.field(\"customer_id\", pa.int64(), nullable=False),\n",
+    "    pa.field(\"name\", pa.string(), nullable=False),\n",
+    "    pa.field(\"email\", pa.string(), nullable=False),\n",
+    "    pa.field(\"city\", pa.string()),\n",
+    "    pa.field(\"state\", pa.string()),\n",
+    "    pa.field(\"country\", pa.string()),\n",
+    "    pa.field(\"segment\", pa.string()),\n",
+    "    pa.field(\"created_date\", pa.string()),\n",
+    "])\n",
+    "\n",
+    "try:\n",
+    "    catalog.drop_table(\"sales.customers\")\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
+    "customers_table = catalog.create_table(\"sales.customers\", schema=customers_schema)\n",
+    "print(f\"Created table: sales.customers\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "customers_data = pa.table({\n",
+    "    \"customer_id\": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],\n",
+    "    \"name\": [\n",
+    "        \"Alice Johnson\", \"Bob Martinez\", \"Carol Williams\", \"David Lee\", \"Eva Brown\",\n",
+    "        \"Frank Chen\", \"Grace Kim\", \"Henry Kim\", \"Iris Patel\", \"Jack Thompson\",\n",
+    "        \"Karen Wilson\", \"Liam Davis\", \"Maria Rodriguez\", \"Nathan Park\", \"Olivia Taylor\",\n",
+    "        \"Paul Anderson\", \"Quinn Murphy\", \"Rachel Green\", \"Sam Wright\", \"Tina Foster\"\n",
+    "    ],\n",
+    "    \"email\": [f\"customer{i}@example.com\" for i in range(1, 21)],\n",
+    "    \"city\": [\n",
+    "        \"New York\", \"Los Angeles\", \"Chicago\", \"Houston\", \"Phoenix\",\n",
+    "        \"San Francisco\", \"Seattle\", \"Boston\", \"Denver\", \"Atlanta\",\n",
+    "        \"Miami\", \"Dallas\", \"Portland\", \"Austin\", \"Nashville\",\n",
+    "        \"Detroit\", \"Minneapolis\", \"San Diego\", \"Philadelphia\", \"Charlotte\"\n",
+    "    ],\n",
+    "    \"state\": [\n",
+    "        \"NY\", \"CA\", \"IL\", \"TX\", \"AZ\", \"CA\", \"WA\", \"MA\", \"CO\", \"GA\",\n",
+    "        \"FL\", \"TX\", \"OR\", \"TX\", \"TN\", \"MI\", \"MN\", \"CA\", \"PA\", \"NC\"\n",
+    "    ],\n",
+    "    \"country\": [\"US\"] * 20,\n",
+    "    \"segment\": [\n",
+    "        \"Enterprise\", \"SMB\", \"Enterprise\", \"Consumer\", \"SMB\",\n",
+    "        \"Enterprise\", \"Consumer\", \"SMB\", \"Enterprise\", \"Consumer\",\n",
+    "        \"SMB\", \"Enterprise\", \"Consumer\", \"SMB\", \"Enterprise\",\n",
+    "        \"Consumer\", \"SMB\", \"Enterprise\", \"Consumer\", \"SMB\"\n",
+    "    ],\n",
+    "    \"created_date\": [\n",
+    "        \"2023-01-15\", \"2023-02-20\", \"2023-03-10\", \"2023-04-05\", \"2023-05-12\",\n",
+    "        \"2023-06-18\", \"2023-07-22\", \"2023-08-30\", \"2023-09-14\", \"2023-10-25\",\n",
+    "        \"2023-11-08\", \"2023-12-01\", \"2024-01-15\", \"2024-02-20\", \"2024-03-10\",\n",
+    "        \"2024-04-05\", \"2024-05-12\", \"2024-06-18\", \"2024-07-22\", \"2024-08-30\"\n",
+    "    ],\n",
+    "}, schema=customers_schema)\n",
+    "\n",
+    "customers_table.append(customers_data)\n",
+    "print(f\"Loaded {len(customers_data)} customers\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Products Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "products_schema = pa.schema([\n",
+    "    pa.field(\"product_id\", pa.int64(), nullable=False),\n",
+    "    pa.field(\"product_name\", pa.string(), nullable=False),\n",
+    "    pa.field(\"category\", pa.string()),\n",
+    "    pa.field(\"unit_price\", pa.float64()),\n",
+    "    pa.field(\"supplier\", pa.string()),\n",
+    "])\n",
+    "\n",
+    "try:\n",
+    "    catalog.drop_table(\"sales.products\")\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
+    "products_table = catalog.create_table(\"sales.products\", schema=products_schema)\n",
+    "print(f\"Created table: sales.products\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "products_data = pa.table({\n",
+    "    \"product_id\": list(range(101, 116)),\n",
+    "    \"product_name\": [\n",
+    "        \"Laptop Pro 15\", \"Wireless Mouse\", \"USB-C Hub\", \"Monitor 27in\", \"Mechanical Keyboard\",\n",
+    "        \"Webcam HD\", \"Headset Pro\", \"Docking Station\", \"External SSD 1TB\", \"4TB SSD\",\n",
+    "        \"Network Switch 24-port\", \"UPS Battery 1500VA\", \"Cable Kit\", \"Laptop Stand\", \"Desk Lamp LED\"\n",
+    "    ],\n",
+    "    \"category\": [\n",
+    "        \"Computers\", \"Accessories\", \"Accessories\", \"Displays\", \"Accessories\",\n",
+    "        \"Peripherals\", \"Audio\", \"Docking\", \"Storage\", \"Storage\",\n",
+    "        \"Networking\", \"Power\", \"Accessories\", \"Furniture\", \"Furniture\"\n",
+    "    ],\n",
+    "    \"unit_price\": [\n",
+    "        1299.99, 29.99, 49.99, 449.99, 149.99,\n",
+    "        79.99, 199.99, 249.99, 109.99, 299.99,\n",
+    "        399.99, 189.99, 24.99, 59.99, 39.99\n",
+    "    ],\n",
+    "    \"supplier\": [\n",
+    "        \"Dell\", \"Logitech\", \"Anker\", \"LG\", \"Keychron\",\n",
+    "        \"Logitech\", \"Jabra\", \"CalDigit\", \"Samsung\", \"Samsung\",\n",
+    "        \"Cisco\", \"APC\", \"Monoprice\", \"Rain Design\", \"BenQ\"\n",
+    "    ],\n",
+    "}, schema=products_schema)\n",
+    "\n",
+    "products_table.append(products_data)\n",
+    "print(f\"Loaded {len(products_data)} products\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Orders Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "orders_schema = pa.schema([\n",
+    "    pa.field(\"order_id\", pa.int64(), nullable=False),\n",
+    "    pa.field(\"customer_id\", pa.int64(), nullable=False),\n",
+    "    pa.field(\"product_id\", pa.int64(), nullable=False),\n",
+    "    pa.field(\"quantity\", pa.int64()),\n",
+    "    pa.field(\"total_amount\", pa.float64()),\n",
+    "    pa.field(\"order_date\", pa.string()),\n",
+    "    pa.field(\"status\", pa.string()),\n",
+    "    pa.field(\"region\", pa.string()),\n",
+    "])\n",
+    "\n",
+    "try:\n",
+    "    catalog.drop_table(\"sales.orders\")\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
+    "orders_table = catalog.create_table(\"sales.orders\", schema=orders_schema)\n",
+    "print(f\"Created table: sales.orders\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "random.seed(42)\n",
+    "\n",
+    "n_orders = 50\n",
+    "statuses = [\"Completed\", \"Completed\", \"Completed\", \"Shipped\", \"Processing\", \"Cancelled\"]\n",
+    "regions = [\"Northeast\", \"Southeast\", \"Midwest\", \"Southwest\", \"West\"]\n",
+    "\n",
+    "order_ids = list(range(5001, 5001 + n_orders))\n",
+    "customer_ids = [random.randint(1, 20) for _ in range(n_orders)]\n",
+    "product_ids = [random.randint(101, 115) for _ in range(n_orders)]\n",
+    "\n",
+    "# Look up prices\n",
+    "price_map = dict(zip(range(101, 116), [\n",
+    "    1299.99, 29.99, 49.99, 449.99, 149.99,\n",
+    "    79.99, 199.99, 249.99, 109.99, 299.99,\n",
+    "    399.99, 189.99, 24.99, 59.99, 39.99\n",
+    "]))\n",
+    "\n",
+    "quantities = [random.randint(1, 10) for _ in range(n_orders)]\n",
+    "totals = [round(quantities[i] * price_map[product_ids[i]], 2) for i in range(n_orders)]\n",
+    "\n",
+    "dates = []\n",
+    "for _ in range(n_orders):\n",
+    "    month = random.randint(1, 12)\n",
+    "    day = random.randint(1, 28)\n",
+    "    dates.append(f\"2024-{month:02d}-{day:02d}\")\n",
+    "\n",
+    "orders_data = pa.table({\n",
+    "    \"order_id\": order_ids,\n",
+    "    \"customer_id\": customer_ids,\n",
+    "    \"product_id\": product_ids,\n",
+    "    \"quantity\": quantities,\n",
+    "    \"total_amount\": totals,\n",
+    "    \"order_date\": dates,\n",
+    "    \"status\": [random.choice(statuses) for _ in range(n_orders)],\n",
+    "    \"region\": [random.choice(regions) for _ in range(n_orders)],\n",
+    "}, schema=orders_schema)\n",
+    "\n",
+    "orders_table.append(orders_data)\n",
+    "print(f\"Loaded {len(orders_data)} orders\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Create Iceberg View\n",
+    "\n",
+    "Iceberg Views let you define virtual tables with SQL that live in the catalog. Dremio (and any other query engine) can query views just like tables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view_payload = json.dumps({\n",
+    "    \"name\": \"revenue_by_region\",\n",
+    "    \"schema\": {\n",
+    "        \"type\": \"struct\",\n",
+    "        \"fields\": [\n",
+    "            {\"id\": 1, \"name\": \"region\", \"type\": \"string\", \"required\": False},\n",
+    "            {\"id\": 2, \"name\": \"total_revenue\", \"type\": \"double\", \"required\": False},\n",
+    "            {\"id\": 3, \"name\": \"order_count\", \"type\": \"long\", \"required\": False}\n",
+    "        ]\n",
+    "    },\n",
+    "    \"view-version\": {\n",
+    "        \"version-id\": 1,\n",
+    "        \"schema-id\": 0,\n",
+    "        \"timestamp-ms\": int(datetime.now().timestamp() * 1000),\n",
+    "        \"summary\": {\"engine-name\": \"PyIceberg\"},\n",
+    "        \"representations\": [\n",
+    "            {\n",
+    "                \"type\": \"sql\",\n",
+    "                \"sql\": \"SELECT region, SUM(total_amount) as total_revenue, COUNT(*) as order_count FROM sales.orders GROUP BY region ORDER BY total_revenue DESC\",\n",
+    "                \"dialect\": \"spark\"\n",
+    "            }\n",
+    "        ],\n",
+    "        \"default-namespace\": [\"sales\"]\n",
+    "    }\n",
+    "})\n",
+    "\n",
+    "resp = make_request(\"POST\", f\"/v1/{WAREHOUSE_NAME}/namespaces/sales/views\", view_payload)\n",
+    "if resp.status_code in [200, 201]:\n",
+    "    print(\"View 'revenue_by_region' created\")\n",
+    "elif resp.status_code == 409:\n",
+    "    print(\"View 'revenue_by_region' already exists\")\n",
+    "else:\n",
+    "    print(f\"View creation: {resp.status_code} - {resp.text}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Verify Data via PyIceberg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"=== Tables in 'sales' namespace ===\")\n",
+    "for table_id in catalog.list_tables(\"sales\"):\n",
+    "    table = catalog.load_table(table_id)\n",
+    "    scan = table.scan()\n",
+    "    df = scan.to_pandas()\n",
+    "    print(f\"  {table_id[1]}: {len(df)} rows\")\n",
+    "\n",
+    "print(\"\\n=== Sample: customers ===\")\n",
+    "print(catalog.load_table(\"sales.customers\").scan().to_pandas().head())\n",
+    "\n",
+    "print(\"\\n=== Sample: products ===\")\n",
+    "print(catalog.load_table(\"sales.products\").scan().to_pandas().head())\n",
+    "\n",
+    "print(\"\\n=== Sample: orders ===\")\n",
+    "print(catalog.load_table(\"sales.orders\").scan().to_pandas().head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 7. Configure Dremio Source\n",
+    "\n",
+    "### Step 1: Create your Dremio admin account\n",
+    "\n",
+    "Before running the cells below, open **http://localhost:9047** in your browser and create your admin account.\n",
+    "\n",
+    "Then update the credentials in the next cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Update these with the admin account you created in Dremio\n# (matches what you set during first-time setup at http://localhost:9047)\nDREMIO_HOST = \"http://dremio:9047\"\nDREMIO_USER = os.environ.get(\"DREMIO_USER\", \"admin\")\nDREMIO_PASS = os.environ.get(\"DREMIO_PASS\", \"\")\n\nif not DREMIO_PASS:\n    raise ValueError(\"Set DREMIO_PASS to your Dremio admin password before running this cell.\\n\"\n                     \"  In Jupyter: kernel > restart, then set os.environ['DREMIO_PASS'] = 'yourpassword'\\n\"\n                     \"  Or set DREMIO_PASS environment variable before starting Jupyter.\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 2: Authenticate with Dremio API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Get Dremio auth token\nauth_resp = requests.post(\n    f\"{DREMIO_HOST}/apiv2/login\",\n    json={\"userName\": DREMIO_USER, \"password\": DREMIO_PASS}\n)\nauth_resp.raise_for_status()\nDREMIO_TOKEN = auth_resp.json()[\"token\"]\nDREMIO_HEADERS = {\n    \"Authorization\": f\"_dremio{DREMIO_TOKEN}\",\n    \"Content-Type\": \"application/json\"\n}\nprint(\"Authenticated with Dremio\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Step 3: Create RESTCATALOG Source\n\nThis connects Dremio to AIStor's built-in Iceberg REST Catalog.\n\n**Key configuration details:**\n- `restEndpointUri` - The Iceberg REST API endpoint (includes `http://`)\n- `fs.s3a.endpoint` - The S3 data endpoint (**must NOT include `http://`** - just `host:port`)\n- `fs.s3a.connection.ssl.enabled` - Must be `false` for non-TLS connections\n- `dremio.s3.compat` - Must be `true` for S3-compatible storage (MinIO)\n- `rest.sigv4-enabled` - AIStor Tables uses SigV4 authentication\n- `rest.access-key-id` / `rest.secret-access-key` - Go in **propertyList** (not secretPropertyList)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "source_config = {\n    \"entityType\": \"source\",\n    \"name\": \"aistor_tables\",\n    \"type\": \"RESTCATALOG\",\n    \"config\": {\n        \"restEndpointUri\": \"http://minio:9000/_iceberg\",\n        \"isUsingVendedCredentials\": False,\n        \"enableAsync\": True,\n        \"isCachingEnabled\": True,\n        \"maxCacheSpacePct\": 100,\n        \"isRecursiveAllowedNamespaces\": True,\n        \"propertyList\": [\n            {\"name\": \"warehouse\", \"value\": WAREHOUSE_NAME},\n            {\"name\": \"rest.sigv4-enabled\", \"value\": \"true\"},\n            {\"name\": \"rest.signing-name\", \"value\": \"s3tables\"},\n            {\"name\": \"rest.signing-region\", \"value\": \"dummy\"},\n            {\"name\": \"rest.access-key-id\", \"value\": ACCESS_KEY},\n            {\"name\": \"rest.secret-access-key\", \"value\": SECRET_KEY},\n            {\"name\": \"fs.s3a.endpoint\", \"value\": \"minio:9000\"},\n            {\"name\": \"fs.s3a.path.style.access\", \"value\": \"true\"},\n            {\"name\": \"fs.s3a.connection.ssl.enabled\", \"value\": \"false\"},\n            {\"name\": \"fs.s3a.aws.credentials.provider\", \"value\": \"org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider\"},\n            {\"name\": \"dremio.s3.compat\", \"value\": \"true\"}\n        ],\n        \"secretPropertyList\": [\n            {\"name\": \"fs.s3a.access.key\", \"value\": ACCESS_KEY},\n            {\"name\": \"fs.s3a.secret.key\", \"value\": SECRET_KEY}\n        ]\n    }\n}\n\n# Create or update source\nresp = requests.post(\n    f\"{DREMIO_HOST}/api/v3/catalog\",\n    headers=DREMIO_HEADERS,\n    json=source_config\n)\n\nif resp.status_code in [200, 201]:\n    source_data = resp.json()\n    print(f\"Source 'aistor_tables' created\")\n    print(f\"Source ID: {source_data.get('id', 'N/A')}\")\nelif resp.status_code == 409:\n    # Source already exists - update it\n    print(\"Source 'aistor_tables' already exists, updating...\")\n    existing = requests.get(\n        f\"{DREMIO_HOST}/api/v3/catalog/by-path/aistor_tables\",\n        headers=DREMIO_HEADERS\n    )\n    if existing.status_code == 200:\n        existing_data = existing.json()\n        source_config[\"tag\"] = existing_data.get(\"tag\")\n        update_resp = requests.put(\n            f\"{DREMIO_HOST}/api/v3/catalog/{existing_data['id']}\",\n            headers=DREMIO_HEADERS,\n            json=source_config\n        )\n        if update_resp.status_code == 200:\n            print(\"Source updated successfully\")\n        else:\n            print(f\"Source update failed: {update_resp.status_code} - {update_resp.text}\")\nelse:\n    print(f\"Source creation failed: {resp.status_code}\")\n    print(resp.text)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify source status\n",
+    "import time\n",
+    "time.sleep(5)  # Give Dremio a moment to connect\n",
+    "\n",
+    "resp = requests.get(\n",
+    "    f\"{DREMIO_HOST}/api/v3/catalog/by-path/aistor_tables\",\n",
+    "    headers=DREMIO_HEADERS\n",
+    ")\n",
+    "if resp.status_code == 200:\n",
+    "    source_info = resp.json()\n",
+    "    status = source_info.get(\"status\", {}).get(\"state\", \"unknown\")\n",
+    "    print(f\"Source status: {status}\")\n",
+    "else:\n",
+    "    print(f\"Could not check source: {resp.status_code}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Query from Dremio\n",
+    "\n",
+    "Now we can run SQL queries through Dremio against the AIStor Tables data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "def dremio_query(sql, timeout=120):\n",
+    "    \"\"\"Submit a SQL query to Dremio and return results as a DataFrame.\"\"\"\n",
+    "    # Submit query\n",
+    "    resp = requests.post(\n",
+    "        f\"{DREMIO_HOST}/api/v3/sql\",\n",
+    "        headers=DREMIO_HEADERS,\n",
+    "        json={\"sql\": sql}\n",
+    "    )\n",
+    "    resp.raise_for_status()\n",
+    "    job_id = resp.json()[\"id\"]\n",
+    "    \n",
+    "    # Poll for completion\n",
+    "    start = time.time()\n",
+    "    while time.time() - start < timeout:\n",
+    "        status_resp = requests.get(\n",
+    "            f\"{DREMIO_HOST}/api/v3/job/{job_id}\",\n",
+    "            headers=DREMIO_HEADERS\n",
+    "        )\n",
+    "        status_resp.raise_for_status()\n",
+    "        job_info = status_resp.json()\n",
+    "        state = job_info[\"jobState\"]\n",
+    "        \n",
+    "        if state == \"COMPLETED\":\n",
+    "            # Fetch results\n",
+    "            results_resp = requests.get(\n",
+    "                f\"{DREMIO_HOST}/api/v3/job/{job_id}/results?offset=0&limit=500\",\n",
+    "                headers=DREMIO_HEADERS\n",
+    "            )\n",
+    "            results_resp.raise_for_status()\n",
+    "            data = results_resp.json()\n",
+    "            columns = [col[\"name\"] for col in data[\"schema\"]]\n",
+    "            return pd.DataFrame(data[\"rows\"], columns=columns)\n",
+    "        elif state == \"FAILED\":\n",
+    "            raise Exception(f\"Query failed: {job_info.get('errorMessage', 'Unknown error')}\")\n",
+    "        elif state == \"CANCELLED\":\n",
+    "            raise Exception(\"Query was cancelled\")\n",
+    "        \n",
+    "        time.sleep(2)\n",
+    "    \n",
+    "    raise TimeoutError(f\"Query did not complete within {timeout} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query: All Customers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dremio_query(\"SELECT * FROM aistor_tables.sales.customers ORDER BY customer_id LIMIT 10\")\n",
+    "print(f\"Returned {len(df)} rows\")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query: Product Catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dremio_query(\"SELECT * FROM aistor_tables.sales.products ORDER BY unit_price DESC\")\n",
+    "print(f\"Returned {len(df)} rows\")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query: Top Orders by Revenue"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dremio_query(\"\"\"\n",
+    "    SELECT \n",
+    "        c.name AS customer,\n",
+    "        p.product_name,\n",
+    "        o.quantity,\n",
+    "        o.total_amount,\n",
+    "        o.order_date,\n",
+    "        o.region\n",
+    "    FROM aistor_tables.sales.orders o\n",
+    "    JOIN aistor_tables.sales.customers c ON o.customer_id = c.customer_id\n",
+    "    JOIN aistor_tables.sales.products p ON o.product_id = p.product_id\n",
+    "    ORDER BY o.total_amount DESC\n",
+    "    LIMIT 15\n",
+    "\"\"\")\n",
+    "print(f\"Top 15 orders by revenue:\")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query: Revenue by Region"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dremio_query(\"\"\"\n",
+    "    SELECT \n",
+    "        region,\n",
+    "        COUNT(*) AS order_count,\n",
+    "        SUM(total_amount) AS total_revenue,\n",
+    "        ROUND(AVG(total_amount), 2) AS avg_order_value\n",
+    "    FROM aistor_tables.sales.orders\n",
+    "    WHERE status = 'Completed'\n",
+    "    GROUP BY region\n",
+    "    ORDER BY total_revenue DESC\n",
+    "\"\"\")\n",
+    "print(\"Revenue by region (completed orders):\")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query: Customer Segment Analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dremio_query(\"\"\"\n",
+    "    SELECT \n",
+    "        c.segment,\n",
+    "        COUNT(DISTINCT c.customer_id) AS customers,\n",
+    "        COUNT(o.order_id) AS orders,\n",
+    "        ROUND(SUM(o.total_amount), 2) AS total_revenue,\n",
+    "        ROUND(AVG(o.total_amount), 2) AS avg_order_value\n",
+    "    FROM aistor_tables.sales.customers c\n",
+    "    LEFT JOIN aistor_tables.sales.orders o ON c.customer_id = o.customer_id\n",
+    "    GROUP BY c.segment\n",
+    "    ORDER BY total_revenue DESC\n",
+    "\"\"\")\n",
+    "print(\"Customer segment analysis:\")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query: Top-Selling Products"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = dremio_query(\"\"\"\n",
+    "    SELECT \n",
+    "        p.product_name,\n",
+    "        p.category,\n",
+    "        p.supplier,\n",
+    "        COUNT(o.order_id) AS times_ordered,\n",
+    "        SUM(o.quantity) AS total_units,\n",
+    "        ROUND(SUM(o.total_amount), 2) AS total_revenue\n",
+    "    FROM aistor_tables.sales.products p\n",
+    "    JOIN aistor_tables.sales.orders o ON p.product_id = o.product_id\n",
+    "    GROUP BY p.product_name, p.category, p.supplier\n",
+    "    ORDER BY total_revenue DESC\n",
+    "\"\"\")\n",
+    "print(\"Top-selling products:\")\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 9. Example SQL Queries for Dremio UI\n",
+    "\n",
+    "You can also run these queries directly in the Dremio SQL editor at **http://localhost:9047**:\n",
+    "\n",
+    "```sql\n",
+    "-- All customers\n",
+    "SELECT * FROM aistor_tables.sales.customers;\n",
+    "\n",
+    "-- Product catalog\n",
+    "SELECT * FROM aistor_tables.sales.products ORDER BY unit_price DESC;\n",
+    "\n",
+    "-- Top orders with customer and product details\n",
+    "SELECT \n",
+    "    c.name AS customer,\n",
+    "    p.product_name,\n",
+    "    o.quantity,\n",
+    "    o.total_amount,\n",
+    "    o.order_date,\n",
+    "    o.region\n",
+    "FROM aistor_tables.sales.orders o\n",
+    "JOIN aistor_tables.sales.customers c ON o.customer_id = c.customer_id\n",
+    "JOIN aistor_tables.sales.products p ON o.product_id = p.product_id\n",
+    "ORDER BY o.total_amount DESC\n",
+    "LIMIT 20;\n",
+    "\n",
+    "-- Revenue by region\n",
+    "SELECT \n",
+    "    region,\n",
+    "    COUNT(*) AS order_count,\n",
+    "    SUM(total_amount) AS total_revenue,\n",
+    "    ROUND(AVG(total_amount), 2) AS avg_order_value\n",
+    "FROM aistor_tables.sales.orders\n",
+    "WHERE status = 'Completed'\n",
+    "GROUP BY region\n",
+    "ORDER BY total_revenue DESC;\n",
+    "\n",
+    "-- Monthly sales trend\n",
+    "SELECT \n",
+    "    SUBSTRING(order_date, 1, 7) AS month,\n",
+    "    COUNT(*) AS orders,\n",
+    "    ROUND(SUM(total_amount), 2) AS revenue\n",
+    "FROM aistor_tables.sales.orders\n",
+    "GROUP BY SUBSTRING(order_date, 1, 7)\n",
+    "ORDER BY month;\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Summary\n\nThis notebook demonstrated the full workflow for using Dremio with AIStor Tables:\n\n1. **Created Iceberg tables** on AIStor using PyIceberg with SigV4 authentication\n2. **Populated tables** with sample e-commerce data (customers, products, orders)\n3. **Created an Iceberg View** for pre-defined analytics\n4. **Configured Dremio** to connect via the RESTCATALOG source type\n5. **Ran SQL queries** through Dremio including multi-table joins\n\n### Key Configuration Notes\n\n| Property | Value | Notes |\n|----------|-------|-------|\n| `restEndpointUri` | `http://minio:9000/_iceberg` | Includes `http://` |\n| `fs.s3a.endpoint` | `minio:9000` | **NO** `http://` prefix |\n| `fs.s3a.connection.ssl.enabled` | `false` | Required for non-TLS |\n| `dremio.s3.compat` | `true` | Required for MinIO/S3-compatible storage |\n| `rest.sigv4-enabled` | `true` | AIStor uses SigV4 auth |\n| `rest.signing-name` | `s3tables` | Service name for SigV4 |\n| `rest.access-key-id` | (in propertyList) | **Not** in secretPropertyList |\n| `fs.s3a.path.style.access` | `true` | Required for MinIO |\n\n### Dremio API Auth\n\nDremio uses `_dremio{TOKEN}` format for the Authorization header (not `Bearer`)."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/aistor-tables-dremio/notebooks/sigv4.py
+++ b/aistor-tables-dremio/notebooks/sigv4.py
@@ -1,0 +1,24 @@
+import hashlib
+import boto3
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+def sign(method, url, body, host, headers, service="s3tables", region="dummy", access_key=None, secret_key=None):
+    session = boto3.Session(
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region
+    )
+    payload_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+    headers['x-amz-content-sha256'] = payload_hash
+    headers['Host'] = host.replace("http://", "").replace("https://", "")
+
+    request = AWSRequest(
+        method=method,
+        url=url,
+        data=body,
+        headers=headers,
+    )
+    SigV4Auth(session.get_credentials(), service, region).add_auth(request)
+    return request

--- a/aistor-tables-dremio/scripts/run.sh
+++ b/aistor-tables-dremio/scripts/run.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+#
+# AIStor Tables + Dremio Enterprise Integration
+# Starts MinIO AIStor, Dremio Enterprise, and Jupyter
+#
+
+set -e
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+print_header() {
+	echo ""
+	echo -e "${BLUE}===============================================${NC}"
+	echo -e "${BLUE}$1${NC}"
+	echo -e "${BLUE}===============================================${NC}"
+	echo ""
+}
+
+print_msg() {
+	local color=$1
+	local msg=$2
+	echo -e "${color}${msg}${NC}"
+}
+
+usage() {
+	cat <<EOF
+AIStor Tables + Dremio Enterprise Integration
+
+USAGE:
+  $0 [options]
+
+DESCRIPTION:
+  Starts MinIO AIStor (with Tables), Dremio Enterprise, and Jupyter notebook.
+
+  NOTE: Dremio Enterprise is required for the RESTCATALOG source type.
+  Get a 30-day trial at https://www.dremio.com/get-started/
+
+OPTIONS:
+  --binary-path PATH     Use pre-built MinIO binary (linux/amd64)
+  --stop                 Stop all services
+  -h, --help             Show this help message
+
+PREREQUISITES:
+  1. Set your AIStor license in .env:
+     MINIO_LICENSE=your-license-key-here
+
+  2. Login to quay.io to pull the Dremio Enterprise image:
+     docker login quay.io -u '<trial-robot-account>' -p '<trial-token>'
+
+ACCESSING SERVICES:
+  MinIO Console:    http://localhost:9001  (minioadmin/minioadmin)
+  Dremio UI:        http://localhost:9047  (first-time setup required)
+  Jupyter Notebook: http://localhost:8888
+
+EXAMPLES:
+  # Start all services
+  $0
+
+  # Start with custom MinIO binary
+  $0 --binary-path ./minio
+
+  # Stop all services
+  $0 --stop
+
+EOF
+	exit 0
+}
+
+# Parse arguments
+BINARY_PATH=""
+STOP_MODE=false
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+	--binary-path)
+		BINARY_PATH="$2"
+		shift 2
+		;;
+	--stop)
+		STOP_MODE=true
+		shift
+		;;
+	-h | --help)
+		usage
+		;;
+	*)
+		echo "Unknown option: $1"
+		usage
+		;;
+	esac
+done
+
+# Stop services
+if [ "$STOP_MODE" = true ]; then
+	print_header "Stopping AIStor Tables + Dremio Services"
+	cd "$PROJECT_ROOT"
+	docker compose down
+	print_msg "$GREEN" "Services stopped"
+	exit 0
+fi
+
+# Load .env
+load_config() {
+	if [ -f "${PROJECT_ROOT}/.env" ]; then
+		print_msg "$YELLOW" "Loading configuration from .env..."
+		set -a
+		source "${PROJECT_ROOT}/.env"
+		set +a
+	fi
+}
+
+# Build from binary if provided
+build_from_binary() {
+	if [ -z "$BINARY_PATH" ]; then
+		return 0
+	fi
+
+	print_header "Building Docker Image from Binary"
+
+	if [ ! -f "$BINARY_PATH" ]; then
+		print_msg "$RED" "MinIO binary not found at $BINARY_PATH"
+		exit 1
+	fi
+
+	if ! file "$BINARY_PATH" | grep -q "ELF 64-bit.*x86-64"; then
+		print_msg "$RED" "Binary must be built for linux/amd64"
+		exit 1
+	fi
+
+	print_msg "$GREEN" "Binary verified (linux/amd64)"
+
+	TEMP_DIR=$(mktemp -d)
+	cp "$BINARY_PATH" "$TEMP_DIR/minio"
+
+	cat > "$TEMP_DIR/Dockerfile" <<'DOCKERFILE'
+FROM ubuntu:22.04
+COPY minio /usr/bin/minio
+RUN chmod +x /usr/bin/minio
+ENTRYPOINT ["/usr/bin/minio"]
+DOCKERFILE
+
+	print_msg "$YELLOW" "Building Docker image: aistor-tables-dremio:latest..."
+	if docker build -t aistor-tables-dremio:latest "$TEMP_DIR"; then
+		print_msg "$GREEN" "Docker image built successfully"
+	else
+		print_msg "$RED" "Failed to build Docker image"
+		rm -rf "$TEMP_DIR"
+		exit 1
+	fi
+
+	rm -rf "$TEMP_DIR"
+	export MINIO_TEST_IMAGE=aistor-tables-dremio:latest
+}
+
+# Start services
+start_services() {
+	print_header "Starting AIStor Tables + Dremio Enterprise"
+
+	cd "$PROJECT_ROOT"
+
+	print_msg "$YELLOW" "Stopping any existing services..."
+	docker compose down 2>/dev/null || true
+
+	print_msg "$YELLOW" "Starting MinIO, Dremio Enterprise, and Jupyter..."
+	if ! docker compose up -d; then
+		print_msg "$RED" "Failed to start services"
+		print_msg "$RED" ""
+		print_msg "$RED" "If you see 'pull access denied', make sure you've logged into quay.io:"
+		print_msg "$RED" "  docker login quay.io -u '<trial-robot-account>' -p '<trial-token>'"
+		exit 1
+	fi
+
+	# Wait for MinIO
+	print_msg "$YELLOW" "Waiting for MinIO to be ready..."
+	for i in {1..30}; do
+		if curl -s -f http://localhost:9000/minio/health/live >/dev/null 2>&1; then
+			print_msg "$GREEN" "MinIO is ready"
+			break
+		fi
+		if [ $i -eq 30 ]; then
+			print_msg "$RED" "MinIO failed to start"
+			exit 1
+		fi
+		sleep 2
+	done
+
+	# Wait for Dremio (takes longer to start)
+	print_msg "$YELLOW" "Waiting for Dremio to be ready (this may take 60-90 seconds)..."
+	for i in {1..60}; do
+		HTTP_CODE=$(curl -sf -o /dev/null -w '%{http_code}' http://localhost:9047 2>/dev/null || echo "000")
+		if echo "$HTTP_CODE" | grep -qE '(200|302|403)'; then
+			print_msg "$GREEN" "Dremio is ready"
+			break
+		fi
+		if [ $i -eq 60 ]; then
+			print_msg "$RED" "Dremio failed to start"
+			print_msg "$RED" "Check logs with: docker compose logs dremio"
+			exit 1
+		fi
+		sleep 3
+	done
+
+	# Wait for Jupyter
+	print_msg "$YELLOW" "Waiting for Jupyter to be ready..."
+	sleep 5
+
+	print_header "All Services Ready!"
+	print_msg "$GREEN" "MinIO Console:    http://localhost:9001"
+	print_msg "$GREEN" "                  (user: minioadmin, password: minioadmin)"
+	print_msg "$GREEN" ""
+	print_msg "$GREEN" "Dremio UI:        http://localhost:9047"
+	print_msg "$YELLOW" "                  (first login: accept EULA + create admin account)"
+	print_msg "$GREEN" ""
+	print_msg "$GREEN" "Jupyter Notebook: http://localhost:8888"
+	print_msg "$GREEN" "                  (no password required)"
+	print_msg "$GREEN" ""
+	print_msg "$BLUE" "Next Steps:"
+	print_msg "$BLUE" "  1. Open Dremio at http://localhost:9047"
+	print_msg "$BLUE" "     - Create your admin account (first-time setup)"
+	print_msg "$BLUE" "  2. Open Jupyter at http://localhost:8888"
+	print_msg "$BLUE" "  3. Run the DremioAIStorTables.ipynb notebook"
+	print_msg "$BLUE" "     - In Step 7, set DREMIO_USER and DREMIO_PASS to match your admin account"
+	print_msg "$GREEN" ""
+	print_msg "$YELLOW" "To stop services: $0 --stop"
+}
+
+# Main
+main() {
+	load_config
+	build_from_binary
+	start_services
+}
+
+main


### PR DESCRIPTION
## Summary

- Adds Docker Compose environment for running MinIO AIStor + Dremio Enterprise locally
- Includes Jupyter notebook (`DremioAIStorTables.ipynb`) walking through Iceberg table creation with PyIceberg and SQL analytics via Dremio's RESTCATALOG source
- `.env.example` provided; `.env` (with real license) excluded via `.gitignore`

## Test plan

- [ ] `cp .env.example .env`, fill in `MINIO_LICENSE` and Dremio image pull creds
- [ ] `docker compose up -d` starts MinIO, Dremio, and Jupyter
- [ ] Run notebook cells in order — warehouse creation, table writes, Dremio source config, SQL queries all succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)